### PR TITLE
[improvement] add FreeBSD native support via XLib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>4.2.0</version>
+            <version>5.5.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -60,6 +60,8 @@
                                 <include>com/sun/jna/win32/*</include>
                                 <include>com/sun/jna/win32-x86/*</include>
                                 <include>com/sun/jna/win32-x86-64/*</include>
+                                <include>com/sun/jna/freebsd-x86/*</include>
+                                <include>com/sun/jna/freebsd-x86-64/*</include>
                             </includes>
                         </filter>
                     </filters>

--- a/src/main/java/com/pavelfatin/typometer/screen/ScreenAccessor.java
+++ b/src/main/java/com/pavelfatin/typometer/screen/ScreenAccessor.java
@@ -26,7 +26,7 @@ public interface ScreenAccessor {
     void dispose();
 
     static boolean isNativeApiSupported() {
-        return Platform.isWindows() || Platform.isLinux();
+        return Platform.isWindows() || Platform.isLinux() || Platform.isFreeBSD();
     }
 
     static ScreenAccessor create(boolean isNative) {
@@ -34,7 +34,7 @@ public interface ScreenAccessor {
             if (Platform.isWindows()) {
                 return new WindowsScreenAccessor();
             }
-            if (Platform.isLinux()) {
+            if (Platform.isLinux() || Platform.isFreeBSD()) {
                 return new LinuxScreenAccessor();
             }
         }


### PR DESCRIPTION
This commit brings ability to run benchmark via JNA/XLib on FreeBSD platform.
Also it bumps version of JNA because version 4.2.0 cause NPE in case of JNA@FreeBSD.

Comparison between native and AWT modes should significant difference: around 5-10ms.

Tested on FreeBSD 13-CURRENT & Gnome 3.x